### PR TITLE
Add ViewPager2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,41 @@ viewPager.adapter = // ... This must be set before attaching
 dots.attachViewPager(viewPager)
 ```
 
+For ViewPager2, it is very similar
+
+```xml
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    >
+
+  <com.afollestad.viewpagerdots.DotsIndicator
+      android:id="@+id/dots"
+      android:layout_width="match_parent"
+      android:layout_height="48dp"
+      />
+
+  <androidx.viewpager2.widget.ViewPager2
+      android:id="@+id/pager"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      />
+
+</LinearLayout>
+```
+
+You attach the view pager to the dots indicator in your code:
+
+```kotlin
+val viewPager: ViewPager2 = // ...
+val dots: DotsIndicator = // ...
+
+viewPager.adapter = // ... This must be set before attaching
+dots.attachViewPager2(viewPager)
+```
+
 ---
 
 ## Customization

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,6 +11,7 @@ ext.versions = [
     bintrayPlugin     : '0.9.1',
 
     kotlin            : '1.3.41',
-    androidx          : '1.0.2',
+    androidx          : '1.1.0',
     androidxAnnotation: '1.1.0',
+    androidxViewpager2: '1.0.0',
 ]

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -31,6 +31,8 @@ dependencies {
   api 'androidx.appcompat:appcompat:' + versions.androidx
 
   implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:' + versions.kotlin
+
+  compileOnly 'androidx.viewpager2:viewpager2:' + versions.androidxViewpager2
 }
 
 apply from: '../spotless.gradle'

--- a/library/src/main/java/com/afollestad/viewpagerdots/DotsIndicator.kt
+++ b/library/src/main/java/com/afollestad/viewpagerdots/DotsIndicator.kt
@@ -280,13 +280,13 @@ class DotsIndicator(
     override fun getInterpolation(value: Float) = abs(1.0f - value)
   }
 
-  interface PagerImpl : Closeable {
+  private interface PagerImpl : Closeable {
     val itemCount: Int?
     val currentItem: Int
     val hasAdapter: Boolean
   }
 
-  class ViewPagerImpl(
+  private class ViewPagerImpl(
     private val viewPager: ViewPager,
     private val pageSelected: (position: Int) -> Unit
   ) : PagerImpl {
@@ -315,7 +315,7 @@ class DotsIndicator(
     }
   }
 
-  class ViewPager2Impl(
+  private class ViewPager2Impl(
     private val viewPager2: ViewPager2,
     private val pageSelected: (position: Int) -> Unit
   ) : PagerImpl {

--- a/library/src/main/java/com/afollestad/viewpagerdots/DotsIndicator.kt
+++ b/library/src/main/java/com/afollestad/viewpagerdots/DotsIndicator.kt
@@ -280,7 +280,7 @@ class DotsIndicator(
     override fun getInterpolation(value: Float) = abs(1.0f - value)
   }
 
-  interface PagerImpl: Closeable {
+  interface PagerImpl : Closeable {
     val itemCount: Int?
     val currentItem: Int
     val hasAdapter: Boolean

--- a/library/src/main/java/com/afollestad/viewpagerdots/DotsIndicator.kt
+++ b/library/src/main/java/com/afollestad/viewpagerdots/DotsIndicator.kt
@@ -182,6 +182,7 @@ class DotsIndicator(
   }
 
   private fun internalPageSelected(position: Int) {
+    if ((pagerImpl?.itemCount ?: 0) <= 0)
     if (animatorIn.isRunning) {
       animatorIn.end()
       animatorIn.cancel()
@@ -202,6 +203,7 @@ class DotsIndicator(
       animatorOut.setTarget(selectedIndicator)
       animatorOut.start()
     }
+    lastPosition = position
   }
 
   private fun createIndicators() {
@@ -262,9 +264,7 @@ class DotsIndicator(
 
   private val internalPageChangeListener = object : ViewPager.OnPageChangeListener {
     override fun onPageSelected(position: Int) {
-      if ((viewPager?.adapter?.count ?: 0) <= 0) return
       internalPageSelected(position)
-      lastPosition = position
     }
 
     override fun onPageScrolled(

--- a/library/src/main/java/com/afollestad/viewpagerdots/DotsIndicator.kt
+++ b/library/src/main/java/com/afollestad/viewpagerdots/DotsIndicator.kt
@@ -33,6 +33,7 @@ import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat.getColor
 import androidx.core.content.ContextCompat.getDrawable
 import androidx.viewpager.widget.ViewPager
+import androidx.viewpager2.widget.ViewPager2
 import java.io.Closeable
 import java.lang.Math.abs
 
@@ -145,6 +146,14 @@ class DotsIndicator(
   fun attachViewPager(viewPager: ViewPager?) {
     if (viewPager != null) {
       attachPagerImpl(ViewPagerImpl(viewPager, this::internalPageSelected))
+    } else {
+      attachPagerImpl(null)
+    }
+  }
+
+  fun attachViewPager2(viewPager2: ViewPager2?) {
+    if (viewPager2 != null) {
+      attachPagerImpl(ViewPager2Impl(viewPager2, this::internalPageSelected))
     } else {
       attachPagerImpl(null)
     }
@@ -303,6 +312,33 @@ class DotsIndicator(
 
     override fun close() {
       viewPager.removeOnPageChangeListener(listener)
+    }
+  }
+
+  class ViewPager2Impl(
+    private val viewPager2: ViewPager2,
+    private val pageSelected: (position: Int) -> Unit
+  ) : PagerImpl {
+
+    private val callback = object : ViewPager2.OnPageChangeCallback() {
+      override fun onPageSelected(position: Int) {
+        pageSelected(position)
+      }
+    }
+
+    init {
+      viewPager2.registerOnPageChangeCallback(callback)
+    }
+
+    override val itemCount: Int?
+      get() = viewPager2.adapter?.itemCount
+    override val currentItem: Int
+      get() = viewPager2.currentItem
+    override val hasAdapter: Boolean
+      get() = viewPager2.adapter != null
+
+    override fun close() {
+      viewPager2.unregisterOnPageChangeCallback(callback)
     }
   }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,6 +24,7 @@ dependencies {
   implementation project(':library')
   implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:' + versions.kotlin
   implementation 'androidx.appcompat:appcompat:' + versions.androidx
+  implementation 'androidx.viewpager2:viewpager2:' + versions.androidxViewpager2
 }
 
 apply from: '../spotless.gradle'

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity android:name="com.afollestad.viewpagerdotssample.ViewPager2Activity"/>
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/afollestad/viewpagerdotssample/MainActivity.kt
+++ b/sample/src/main/java/com/afollestad/viewpagerdotssample/MainActivity.kt
@@ -15,18 +15,28 @@
  */
 package com.afollestad.viewpagerdotssample
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import kotlinx.android.synthetic.main.activity_main.dots
 import kotlinx.android.synthetic.main.activity_main.frame
 import kotlinx.android.synthetic.main.activity_main.pager
+import kotlinx.android.synthetic.main.activity_main.toolbar
 
 class MainActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
+
+    toolbar.inflateMenu(R.menu.main)
+    toolbar.setOnMenuItemClickListener { item ->
+      if (item.itemId == R.id.go_to_viewpager2) {
+        startActivity(Intent(this, ViewPager2Activity::class.java))
+      }
+      true
+    }
 
     pager.adapter = MainPagerAdapter()
     pager.offscreenPageLimit = 3

--- a/sample/src/main/java/com/afollestad/viewpagerdotssample/Util.kt
+++ b/sample/src/main/java/com/afollestad/viewpagerdotssample/Util.kt
@@ -17,6 +17,7 @@ package com.afollestad.viewpagerdotssample
 
 import android.graphics.Color
 import androidx.viewpager.widget.ViewPager
+import androidx.viewpager2.widget.ViewPager2
 
 internal fun ViewPager.onPageSelected(selection: (Int) -> Unit) {
   addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
@@ -29,6 +30,14 @@ internal fun ViewPager.onPageSelected(selection: (Int) -> Unit) {
       positionOffset: Float,
       positionOffsetPixels: Int
     ) = Unit
+  })
+}
+
+internal fun ViewPager2.onPageSelected(selection: (Int) -> Unit) {
+  registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+    override fun onPageSelected(position: Int) {
+      selection(position)
+    }
   })
 }
 

--- a/sample/src/main/java/com/afollestad/viewpagerdotssample/ViewPager2Activity.kt
+++ b/sample/src/main/java/com/afollestad/viewpagerdotssample/ViewPager2Activity.kt
@@ -1,0 +1,44 @@
+package com.afollestad.viewpagerdotssample
+
+import android.content.Context
+import android.os.Bundle
+import androidx.annotation.ColorRes
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import kotlinx.android.synthetic.main.activity_viewpager2.*
+
+class ViewPager2Activity : AppCompatActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_viewpager2)
+
+    val adapter = ViewPager2Adapter(listOf(
+      Page(R.color.blue, "Page One", "One"),
+      Page(R.color.red, "Page Two", "Two"),
+      Page(R.color.white, "Page Three", "Three"),
+      Page(R.color.green, "Page Four", "Four")
+    ))
+    pager.adapter = adapter
+    pager.offscreenPageLimit = 3
+    dots.attachViewPager2(pager)
+
+    pager.onPageSelected { position ->
+      val page = adapter.getItem(position)
+      frame.setBackgroundColor(ContextCompat.getColor(this, page.backgroundColorRes))
+      dots.setDotTintRes(page.getTintColorRes(this))
+    }
+  }
+}
+
+data class Page(
+  @ColorRes val backgroundColorRes: Int,
+  val body: String,
+  val title: String
+) {
+  @ColorRes
+  fun getTintColorRes(context: Context): Int {
+    val backgroundColor = ContextCompat.getColor(context, backgroundColorRes)
+    return if (backgroundColor.isColorLight()) R.color.black else R.color.white
+  }
+}

--- a/sample/src/main/java/com/afollestad/viewpagerdotssample/ViewPager2Activity.kt
+++ b/sample/src/main/java/com/afollestad/viewpagerdotssample/ViewPager2Activity.kt
@@ -1,3 +1,18 @@
+/**
+ * Designed and developed by Aidan Follestad (@afollestad)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.afollestad.viewpagerdotssample
 
 import android.content.Context

--- a/sample/src/main/java/com/afollestad/viewpagerdotssample/ViewPager2Adapter.kt
+++ b/sample/src/main/java/com/afollestad/viewpagerdotssample/ViewPager2Adapter.kt
@@ -1,3 +1,18 @@
+/**
+ * Designed and developed by Aidan Follestad (@afollestad)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.afollestad.viewpagerdotssample
 
 import android.view.ViewGroup
@@ -32,4 +47,3 @@ class ViewPager2Adapter(
 
   fun getItem(position: Int): Page = pages[position]
 }
-

--- a/sample/src/main/java/com/afollestad/viewpagerdotssample/ViewPager2Adapter.kt
+++ b/sample/src/main/java/com/afollestad/viewpagerdotssample/ViewPager2Adapter.kt
@@ -1,0 +1,35 @@
+package com.afollestad.viewpagerdotssample
+
+import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.widget.TextView
+import androidx.appcompat.view.ContextThemeWrapper
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+
+class ViewPager2Adapter(
+  private val pages: List<Page>
+) : RecyclerView.Adapter<ViewPager2Adapter.Holder>() {
+
+  class Holder(val textView: TextView) : RecyclerView.ViewHolder(textView)
+
+  override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
+    val tv = AppCompatTextView(ContextThemeWrapper(parent.context, R.style.PageText))
+    tv.layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+    return Holder(tv)
+  }
+
+  override fun onBindViewHolder(holder: Holder, position: Int) {
+    val context = holder.itemView.context
+    val page = pages[position]
+    val tintColor = ContextCompat.getColor(context, page.getTintColorRes(context))
+    holder.textView.setTextColor(tintColor)
+    holder.textView.text = page.body
+  }
+
+  override fun getItemCount() = pages.size
+
+  fun getItem(position: Int): Page = pages[position]
+}
+

--- a/sample/src/main/res/layout/activity_viewpager2.xml
+++ b/sample/src/main/res/layout/activity_viewpager2.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".ViewPager2Activity"
+    >
+
+  <androidx.appcompat.widget.Toolbar
+      android:id="@+id/toolbar"
+      android:layout_width="match_parent"
+      android:layout_height="?actionBarSize"
+      android:background="?colorPrimary"
+      android:elevation="4dp"
+      app:title="ViewPagerDots Sample (ViewPager2)"
+      tools:ignore="UnusedAttribute"
+      />
+
+  <FrameLayout
+      android:id="@+id/frame"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:background="@color/blue"
+      >
+
+    <com.afollestad.viewpagerdots.DotsIndicator
+        android:id="@+id/dots"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        />
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:ignore="HardcodedText"
+        />
+
+  </FrameLayout>
+
+</LinearLayout>

--- a/sample/src/main/res/menu/main.xml
+++ b/sample/src/main/res/menu/main.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:id="@+id/go_to_viewpager2" android:title="ViewPager2" app:showAsAction="ifRoom|withText"/>
+</menu>


### PR DESCRIPTION
Add `DotsIndicator.attachViewPager2(ViewPager2)` method to allow dots indicator to be used with ViewPager2 as well. 

I added viewpager2 as a `compileOnly` dependency, so people who don't use `attachViewPager2` won't have `ViewPager2` pulled into their project.

`assets/sample.apk` needs recompiling, did you just do an unsigned debug build to create that?

Fixes #2